### PR TITLE
Fix json parsing

### DIFF
--- a/Example_Scripts/Ex1_Templates.py
+++ b/Example_Scripts/Ex1_Templates.py
@@ -6,10 +6,7 @@
 # Copyright 2013, Urban Airship, Inc.
 ##########################################
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 import sys
 
 from passtools import PassTools

--- a/passtools/pt_client.py
+++ b/passtools/pt_client.py
@@ -13,11 +13,7 @@ HTTP interface to PassTools REST API, used indirectly, via other PassTools class
 
 import copy
 import requests
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 
 from passtools import PassTools
 
@@ -37,6 +33,7 @@ def __pt_request(request_func, request_url_frag, request_data = {}):
     @param request_data: Request parameters
     @return: json form of template full-form description
     """
+
     if not PassTools.api_key:
         raise RuntimeError("No API secret key provided. Cannot continue.")
     request_url = "%s%s" % (PassTools.base_url, request_url_frag)
@@ -114,17 +111,16 @@ def pt_delete(request_url_frag, request_data = {}):
 
 def __raise_for_status(response):
     # Override the version in Requests so I can get better reporting
-
     http_error_msg = ''
 
     if 400 <= response.status_code < 500:
-
         decoded_content = ""
-        content_dict = json.loads(response.content, encoding='ISO-8859-1')
-        if "description" in content_dict:
-            decoded_content += content_dict['description'] + " "
-        if "details" in content_dict:
-            decoded_content += content_dict['details']
+        if response.content:
+            content_dict = json.loads(response.content, encoding='ISO-8859-1')
+            if "description" in content_dict:
+                decoded_content += content_dict['description'] + " "
+            if "details" in content_dict:
+                decoded_content += content_dict['details']
         http_error_msg = '%s Client Error: %s. %s' % (response.status_code, response.reason, decoded_content)
 
     elif 500 <= response.status_code < 600:

--- a/passtools/pt_pass.py
+++ b/passtools/pt_pass.py
@@ -11,11 +11,7 @@ Define and provide methods for manipulating PassTools Pass objects.
 
 """
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
+import json
 import urllib
 import pt_client
 from passtools import PassTools

--- a/passtools/pt_project.py
+++ b/passtools/pt_project.py
@@ -1,7 +1,4 @@
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 import urllib
 import pt_client
 

--- a/passtools/pt_tag.py
+++ b/passtools/pt_tag.py
@@ -1,8 +1,4 @@
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
+import json
 import urllib
 from urllib import quote_plus
 import pt_client

--- a/passtools/pt_template.py
+++ b/passtools/pt_template.py
@@ -10,11 +10,7 @@
 Define and provide methods for manipulating PassTools Template objects.
 
 """
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
+import json
 import urllib
 import pt_client
 


### PR DESCRIPTION
Fix json parsing. HTTP responses with empty bodies were causing JSON parsing error. Now we only parse the body if there is one. Also clean up simplejson vs. json.
